### PR TITLE
Fixed Worlds Page Navigation Bar

### DIFF
--- a/views/user/server/players.ejs
+++ b/views/user/server/players.ejs
@@ -18,9 +18,12 @@
 
       <!-- Daemon down message removed as requested -->
 
+      <!-- Server Template -->
+      <%- include('../../components/serverTemplate', { features: ['players', 'worlds'] }) %>
+
       <!-- Error Message -->
       <% if (errorMessage && errorMessage.message) { %>
-      <div class="rounded-xl bg-red-800/10 px-6 py-4 mt-8 mx-8">
+      <div class="rounded-xl bg-red-800/10 px-6 py-4 mt-4 mx-8 mb-4">
         <div class="flex items-center">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-400 mr-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -34,9 +37,6 @@
         </div>
       </div>
       <% } %>
-
-      <!-- Server Template -->
-      <%- include('../../components/serverTemplate') %>
 
       <!-- Players Section -->
       <div class="p-6">

--- a/views/user/server/worlds.ejs
+++ b/views/user/server/worlds.ejs
@@ -18,7 +18,7 @@
 
       <!-- Daemon down message removed as requested -->
 
-<!-- Server Template -->
+      <!-- Server Template -->
       <%- include('../../components/serverTemplate', { features: ['players', 'worlds'] }) %>
 
       <div class="p-6">

--- a/views/user/server/worlds.ejs
+++ b/views/user/server/worlds.ejs
@@ -19,7 +19,7 @@
       <!-- Daemon down message removed as requested -->
 
       <!-- Server Template -->
-      <%- include('../../components/serverTemplate', { features: ['players', 'worlds'] }) %>
+      <%- include('../../components/serverTemplate') %>
 
       <div class="p-6">
         <!-- Error message -->

--- a/views/user/server/worlds.ejs
+++ b/views/user/server/worlds.ejs
@@ -18,8 +18,8 @@
 
       <!-- Daemon down message removed as requested -->
 
-      <!-- Server Template -->
-      <%- include('../../components/serverTemplate') %>
+<!-- Server Template -->
+      <%- include('../../components/serverTemplate', { features: ['players', 'worlds'] }) %>
 
       <div class="p-6">
         <!-- Error message -->


### PR DESCRIPTION
There was an issue on the Worlds Page of the Server Dashboard where the Players and Worlds tab were not showing in the Navigation Bar when the Node is offline. With this changes I was able to fix this issue.

Before:
<img width="1059" height="479" alt="image" src="https://github.com/user-attachments/assets/683bfe96-7309-48b6-9896-52fa415c6800" />

After:
<img width="1656" height="547" alt="image" src="https://github.com/user-attachments/assets/a973a001-bdc3-4008-9639-57ed1e9e93f3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the inclusion of the server template to a single, parameterized instance at the top of the main content.
* **Style**
  * Adjusted spacing around the error message for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->