### PR TITLE
Fixed Worlds Page Navigation Bar

### DIFF
--- a/views/user/server/worlds.ejs
+++ b/views/user/server/worlds.ejs
@@ -19,7 +19,7 @@
       <!-- Daemon down message removed as requested -->
 
       <!-- Server Template -->
-      <%- include('../../components/serverTemplate') %>
+      <%- include('../../components/serverTemplate', { features: ['players', 'worlds'] }) %>
 
       <div class="p-6">
         <!-- Error message -->


### PR DESCRIPTION
There was an issue on the Worlds Page of the Server Dashboard where the Players and Worlds tab were not showing in the Navigation Bar when the Node is offline. With this changes I was able to fix this issue.

Before:
<img width="1059" height="479" alt="image" src="https://github.com/user-attachments/assets/efbbe794-645c-412d-8627-d778481023b7" />

After:
<img width="1656" height="547" alt="image" src="https://github.com/user-attachments/assets/16924711-356e-4be2-b8e7-fbcca80abb62" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated server view to enable additional features related to players and worlds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->