### PR TITLE
Fix redirect from Mobile Server page to Admin Server page

### DIFF
--- a/views/mobile/components/serverTemplate.ejs
+++ b/views/mobile/components/serverTemplate.ejs
@@ -20,7 +20,9 @@
     <% } else {
       menuItems.forEach(item => {
         if (item.feature && !features.includes(item.feature)) return;
-        const url = item.url.replace(':uuid', server.UUID);
+        const url = (item.url || '#')
+          .replace(':uuid', server.UUID)
+          .replace(':id', server.id);
     %>
     <a href="<%= url %>" class="nav-link2 px-3 py-2 text-xs font-medium rounded-lg border border-transparent text-neutral-600 dark:text-neutral-400 whitespace-nowrap" data-active="false"><%= item.label %></a>
     <% }); } %>


### PR DESCRIPTION
Previously it didn't work for mobile.
Now it's fixed.

See https://github.com/airlinklabs/panel/pull/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu link handling to gracefully manage missing URLs and properly support dynamic server references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->