### PR TITLE
Example: Enforce subuser permissions in Client API (#75)

### DIFF
--- a/docs/fix-guides/issue-75-client-api-auth.md
+++ b/docs/fix-guides/issue-75-client-api-auth.md
@@ -1,0 +1,61 @@
+# Example fix for #75
+
+The Client API must authorize every server-scoped operation after resolving server membership. Membership is not an operation permission.
+
+## Target flow
+
+```text
+API credential
+  -> user
+  -> server
+  -> owner OR subuser membership
+  -> required permission for this operation
+  -> daemon/database action
+```
+
+## Suggested authorization context
+
+Refactor the current server resolver so it returns the membership context instead of only `server`:
+
+```ts
+type ServerAccess = {
+  server: Server;
+  isOwner: boolean;
+  subUser: SubUser | null;
+};
+```
+
+Then introduce a single operation guard:
+
+```ts
+function requireServerPermission(access: ServerAccess, permission: string) {
+  if (access.isOwner) return;
+  if (!access.subUser || !hasSubUserPermission(access.subUser.permissions, permission)) {
+    throw new ClientApiError(403, 'permission denied');
+  }
+}
+```
+
+Do not create a second permission vocabulary. Reuse the existing canonical subuser permission parser/wildcard behavior.
+
+## Required audit
+
+Review every endpoint in `src/modules/api/client/clientApi.ts`, including reads and mutations:
+
+- files: list/read/write/delete/rename
+- power actions
+- console/command operations
+- backups: list/create/delete
+- schedules: list/create/update/delete
+
+Each route should have an explicit permission mapping in code.
+
+## Security invariant
+
+A subuser with server membership but no permission must fail before any daemon request or database mutation occurs.
+
+Authorization should be evaluated against the current membership record on each request unless a deliberately short-lived authorization cache is introduced with invalidation on membership changes.
+
+## Tests
+
+Add a parameterized matrix covering owner, permitted subuser, denied subuser, deleted subuser, and non-member. Assert that denied requests do not invoke daemon/database side effects.


### PR DESCRIPTION
## Purpose

Draft example for #75. This PR is intentionally not merge-ready. It provides a concrete authorization design for the Client API.

The branch adds `docs/fix-guides/issue-75-client-api-auth.md`, covering the required access context, operation-to-permission mapping, side-effect ordering, and test matrix.

## Required behavior

Server membership establishes scope, not permission. Every server-scoped Client API operation must perform an operation-specific subuser permission check before any daemon/database side effect.

## Implementation direction

- Return owner/subuser context from the server resolver.
- Reuse the existing subuser permission parser and wildcard semantics.
- Define an explicit required permission per endpoint.
- Reject before `daemonRequest()` or database mutation.
- Add allowed/denied tests for every privileged operation.

References #75