### PR TITLE
Example: Preserve session TTL semantics on Redis touch (#78)

### DIFF
--- a/docs/fix-guides/issue-78-session-ttl.md
+++ b/docs/fix-guides/issue-78-session-ttl.md
@@ -1,0 +1,26 @@
+# Example fix for #78
+
+`RedisSessionStore.set()` derives TTL from `sess.cookie.maxAge`, but `touch()` currently ignores the supplied session and always applies the seven-day default.
+
+## Correct behavior
+
+Use one TTL policy for both initial persistence and refresh:
+
+```ts
+touch(sid: string, sess: session.SessionData, callback?: () => void): void {
+  const ttlSec = this.getTTL(sess);
+  this.redis.expire(`${this.prefix}${sid}`, ttlSec)
+    .then(() => callback?.())
+    .catch(() => callback?.());
+}
+```
+
+The implementation should also confirm that session activity is intended to be sliding expiration rather than an absolute lifetime. If an absolute maximum is desired, store the original expiry/issued timestamp and cap refreshes accordingly.
+
+## Index consistency
+
+The `airlink:usr:{userId}` set is also given a TTL during `set()`. Ensure its expiration cannot outlive the last valid session in a way that creates stale authorization/revocation state.
+
+## Tests
+
+Verify normal and remember-me sessions have the expected TTL after creation and after repeated `touch()` calls. Verify destroying/revoking a session cannot be undone by a later touch. Include index cleanup/expiration tests.


### PR DESCRIPTION
## Purpose

Draft example for #78. This PR documents the intended fix for `RedisSessionStore.touch()` and the tests needed to prevent session lifetime drift.

The guide in `docs/fix-guides/issue-78-session-ttl.md` shows the minimal correction: derive the TTL from the supplied session instead of always applying the seven-day default, while preserving an explicit sliding-vs-absolute expiration policy.

## Implementation direction

- Make `touch()` use the same TTL derivation as `set()`.
- Keep normal and remember-me lifetime semantics consistent.
- Verify user-session index expiry remains coherent.
- Ensure revoked/destroyed sessions cannot be revived through a later touch.
- Add tests for repeated touch and revocation.

References #78