### PR TITLE
Example: Replace memory-buffered uploads with bounded streaming (#79)

### DIFF
--- a/docs/fix-guides/issue-79-upload-streaming.md
+++ b/docs/fix-guides/issue-79-upload-streaming.md
@@ -1,0 +1,33 @@
+# Example fix for #79
+
+The current upload path uses Multer `memoryStorage()`, so the entire multipart file is resident in Node.js memory before downstream chunking begins.
+
+## Target architecture
+
+```text
+HTTP multipart
+  -> bounded parser
+  -> authorization/target validation
+  -> fixed-size stream chunk
+  -> daemon
+  -> release buffer
+  -> next chunk
+```
+
+If the daemon protocol cannot accept a streaming request, use a disk-backed temporary file and read it incrementally. Do not use process heap as the storage layer for potentially multi-gigabyte files.
+
+## Backpressure
+
+The HTTP readable stream must not continue consuming the body while the daemon is unable to accept more data. The implementation should use stream backpressure and await downstream writes/acks where the protocol supports them.
+
+## Failure handling
+
+Handle client disconnects, daemon disconnects, timeouts, cancellation, and disk-full conditions. Temporary artifacts must be removed on all completion/error paths. Consider startup cleanup for orphaned temporary files after process termination.
+
+## Limits
+
+Keep separate controls for request size, maximum file size, chunk size, and optional per-user/concurrent-upload limits. The maximum file size must not imply equivalent heap usage.
+
+## Tests
+
+Add an integration test with a large generated stream and instrument the pipeline to verify bounded buffering. Add concurrent-upload, slow-daemon, client-abort, daemon-failure, oversize, and cleanup tests.


### PR DESCRIPTION
## Purpose

Draft example for #79. This PR is intentionally not merge-ready. It provides the target upload architecture and resource-management requirements.

The guide in `docs/fix-guides/issue-79-upload-streaming.md` covers bounded multipart parsing, backpressure, cancellation, temporary-file cleanup, and concurrency tests.

## Implementation direction

- Remove `memoryStorage()` for multi-gigabyte uploads.
- Stream or use disk-backed temporary storage.
- Apply downstream backpressure.
- Clean up on disconnect/error/cancellation.
- Keep explicit request, file-size, chunk-size, and concurrency limits.

References #79