### PR TITLE
Example: Make administrator permission checks explicit (#81)

### DIFF
--- a/docs/fix-guides/issue-81-admin-permissions.md
+++ b/docs/fix-guides/issue-81-admin-permissions.md
@@ -1,0 +1,31 @@
+# Example fix for #81
+
+The current `isAuthenticated(true, permission)` signature is ambiguous because the admin branch can return before evaluating `permission`.
+
+## Recommended API
+
+Split authentication, administrator status, and permission checks into explicit steps:
+
+```ts
+isAuthenticated(),
+requireAdmin(),
+requireAdminPermission('airlink.admin.nodes.view')
+```
+
+Or expose one helper for granular admin permissions:
+
+```ts
+requireAdminPermission('airlink.admin.nodes.view')
+```
+
+The important invariant is that a permission string supplied by a route must never be silently ignored.
+
+## Audit
+
+Search all uses of `isAuthenticated(true, ...)` and classify them as either unrestricted administrator-only routes or routes that require a specific permission. Pay special attention to destructive operations such as user deletion, node deletion, credential management, addon management, and settings changes.
+
+If the intended model is that every administrator is unrestricted, remove the misleading granular permission arguments instead of keeping a permission system that has no effect.
+
+## Tests
+
+Test normal users, administrators with the required permission, administrators without it, administrators with unrelated permissions, and wildcard permissions. Add representative route tests for both read and destructive actions.


### PR DESCRIPTION
## Purpose

Draft example for #81. This PR is intentionally not merge-ready. It documents the authorization API shape that prevents route declarations from silently ignoring requested permissions.

The guide in `docs/fix-guides/issue-81-admin-permissions.md` shows the recommended separation between authentication, administrator status, and granular permission checks, plus the route audit and regression matrix.

## Implementation direction

- Replace ambiguous `isAuthenticated(true, permission)` semantics.
- Make granular admin permission enforcement explicit.
- Audit all admin routes and classify them.
- Test admins with required, unrelated, missing, and wildcard permissions.

References #81