### PR TITLE
Example: Enforce subuser permissions in Client API

### DIFF
--- a/src/modules/api/client/authorization.ts
+++ b/src/modules/api/client/authorization.ts
@@ -1,0 +1,29 @@
+import type { Server } from '@prisma/client';
+import prisma from '../../../db';
+import { subUserHasPermission } from '../../../handlers/utils/auth/serverAuthUtil';
+
+export type ClientApiServerAccess = {
+  server: Server;
+  isOwner: boolean;
+};
+
+/** Resolve server scope and enforce an operation-level subuser permission. */
+export async function resolveClientApiServerAccess(
+  serverId: string,
+  userId: number,
+  permission: Parameters<typeof subUserHasPermission>[1],
+): Promise<ClientApiServerAccess | null> {
+  const server = await prisma.server.findUnique({ where: { UUID: serverId } });
+  if (!server) return null;
+
+  if (server.ownerId === userId) {
+    return { server, isOwner: true };
+  }
+
+  const subUser = await prisma.subUser.findUnique({
+    where: { serverId_userId: { serverId: server.UUID, userId } },
+  });
+  if (!subUser || !subUserHasPermission(subUser, permission)) return null;
+
+  return { server, isOwner: false };
+}


### PR DESCRIPTION
## Purpose

Example implementation scaffold for #75 using an actual reusable source-level authorization helper. This PR is intentionally a **draft and must not be merged as-is**.

## What changed

- Added `src/modules/api/client/authorization.ts`.
- Resolves owner vs. subuser access explicitly.
- Requires an operation-level subuser permission for non-owner access.
- Reuses the existing canonical `subUserHasPermission()` implementation rather than creating a second permission vocabulary.
- Returns `null` before downstream work when membership or permission is missing.

## Follow-up before merge

Wire `resolveClientApiServerAccess()` into every server-scoped Client API route and add endpoint-specific regression tests proving unauthorized subusers cannot reach daemon/database side effects.

References #75.