### PR TITLE
Example: Bound upload buffering with streamed chunks

### DIFF
--- a/src/utils/uploadStream.ts
+++ b/src/utils/uploadStream.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+
+export const DEFAULT_UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024;
+
+/**
+ * Stream a temporary upload file in bounded chunks. Consumers must await each
+ * chunk handler so a slow daemon applies backpressure to the upload pipeline.
+ */
+export async function forEachUploadChunk(
+  filePath: string,
+  chunkSize = DEFAULT_UPLOAD_CHUNK_SIZE,
+  onChunk: (chunk: Buffer, index: number, totalChunks: number) => Promise<void>,
+): Promise<void> {
+  const stat = await fs.promises.stat(filePath);
+  const totalChunks = Math.ceil(stat.size / chunkSize);
+  const stream = fs.createReadStream(filePath, { highWaterMark: chunkSize });
+  let index = 0;
+
+  try {
+    for await (const chunk of stream) {
+      await onChunk(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk), index, totalChunks);
+      index += 1;
+    }
+  } finally {
+    stream.destroy();
+  }
+}


### PR DESCRIPTION
## Purpose

Example source-level improvement for #79. This PR is intentionally a **draft and unmerged**.

## What changed

- Adds `forEachUploadChunk()` to stream temporary upload files using a bounded `highWaterMark`.
- Awaits each consumer callback so a slow daemon naturally applies backpressure.
- Ensures the stream is destroyed on completion/error.

## Follow-up before merge

Replace the upload handler's `memoryStorage()` path with disk-backed multipart storage and use this helper for the large-file branch. Add resource-cleanup and concurrent-upload tests.

References #79.